### PR TITLE
新增私聊中启用AI聊天的配置项，整理配置相关的代码，修复一些小问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 | xiaoai_apikey  | string         |寄         |xiaoai_apikey = "abc1145141919810"       |    小爱同学的apiKey, 详细请看下文        |
 | Bot_NICKNAME   | string         |脑积水     |Bot_NICKNAME = "Hinata"                  |      你Bot的称呼                         |
 | Bot_MASTER     | string         |脑积水     |Bot_MASTER = "星野日向_Official"          |      你Bot主人的称呼                     |
+| ai_reply_private  | boolean |false     |ai_reply_private = true          |    私聊时是否启用AI聊天（不影响功能性指令）            |
 | openai_api_key    | string  |寄        |openai_api_key = "aabb114514"    |    openai的api_key, 详细请看下文         |
 | openai_max_tokens | int     |1000      |openai_max_tokens = 1500         |    openai的max_tokens, 详细请看下文     |
 | openai_cd_time    | int     |60        |openai_cd_time = 114             |    openai调用的cd                       |

--- a/nonebot_plugin_smart_reply/__init__.py
+++ b/nonebot_plugin_smart_reply/__init__.py
@@ -17,6 +17,8 @@ from nonebot.adapters.onebot.v11 import (
 )
 
 
+openai_cd_dir = {}  # 用于存放cd时间
+
 # 添加和删除关键词
 add_new = on_regex(
     r"^添加关键词\s*(\S+.*?)\s*答\s*(\S+.*?)\s*$",

--- a/nonebot_plugin_smart_reply/__init__.py
+++ b/nonebot_plugin_smart_reply/__init__.py
@@ -16,13 +16,6 @@ from nonebot.adapters.onebot.v11 import (
 )
 
 
-try:
-    cd_time = nonebot.get_driver().config.openai_cd_time
-except:
-    cd_time = 60        # 默认cd时间为60秒
-
-openai_cd_dir = {}  # 用于存放cd时间
-
 # 添加和删除关键词
 add_new = on_regex(
     r"^添加关键词\s*(\S+.*?)\s*答\s*(\S+.*?)\s*$",
@@ -183,8 +176,8 @@ async def _(event: MessageEvent):
             message = await qinyun_reply(qinyun_url)
             logger.info("来自青云客的智能回复: " + message)
         else:
-            xiaoai_url = f"https://apibug.cn/api/xiaoai/?msg={msg}&apiKey={apiKey}"
-            if apiKey == "寄":
+            xiaoai_url = f"https://apibug.cn/api/xiaoai/?msg={msg}&apiKey={xiaoai_api_key}"
+            if xiaoai_api_key == "寄":
                 await ai.finish("小爱同学apiKey未设置, 请联系SUPERUSERS在.env中设置")
             message = await xiaoice_reply(xiaoai_url)
             if message == "寄":
@@ -211,7 +204,7 @@ async def _poke_event(event: PokeNotifyEvent):
 
 @openai_text.handle()
 async def _(event: MessageEvent, msg: Message = CommandArg()):
-    if api_key == "寄":
+    if openai_api_key == "寄":
         # 没有配置openai_api_key
         await openai_text.finish("请先配置openai_api_key")
     prompt = msg.extract_plain_text()                               # 获取文本

--- a/nonebot_plugin_smart_reply/__init__.py
+++ b/nonebot_plugin_smart_reply/__init__.py
@@ -9,6 +9,7 @@ from nonebot.params import CommandArg, RegexGroup, ArgPlainText
 from nonebot.plugin.on import on_message, on_notice, on_command, on_regex
 from nonebot.adapters.onebot.v11 import (
     GroupMessageEvent,
+    PrivateMessageEvent,
     Message,
     MessageEvent,
     PokeNotifyEvent,
@@ -146,6 +147,10 @@ async def _():
 
 @ai.handle()
 async def _(event: MessageEvent):
+    # 配置私聊不启用后，私聊信息直接结束处理
+    if not reply_private and isinstance(event, PrivateMessageEvent):
+        await ai.finish()
+        return
     # 获取消息文本
     msg = str(event.get_message())
     # 去掉带中括号的内容(去除cq码)

--- a/nonebot_plugin_smart_reply/__init__.py
+++ b/nonebot_plugin_smart_reply/__init__.py
@@ -222,7 +222,7 @@ async def _(event: MessageEvent, msg: Message = CommandArg()):
     ):                                                                          # 超过cd时间或者是超级用户
         # 记录cd
         openai_cd_dir.update({qid: event.time})
-        await openai_text.send(MessageSegment.text("让本喵想想吧..."))        # 发送消息
+        await openai_text.send(MessageSegment.text(f"让{Bot_NICKNAME}想想吧..."))        # 发送消息
         loop = asyncio.get_event_loop()                                # 获取事件循环
         try:
             # 开一个不会阻塞asyncio的线程调用get_openai_reply函数
@@ -234,6 +234,6 @@ async def _(event: MessageEvent, msg: Message = CommandArg()):
     else:
         await openai_text.finish(
             MessageSegment.text(
-                f"让本喵的脑子休息一下好不好喵, {cd_time - cd:.0f}秒后才能再次使用"),   # 发送cd时间
+                f"让{Bot_NICKNAME}的脑子休息一下好不好喵, {cd_time - cd:.0f}秒后才能再次使用"),   # 发送cd时间
             at_sender=True
         )

--- a/nonebot_plugin_smart_reply/utils.py
+++ b/nonebot_plugin_smart_reply/utils.py
@@ -12,28 +12,13 @@ except ModuleNotFoundError:
 from httpx import AsyncClient
 
 
-try:
-    apiKey: str = nonebot.get_driver().config.xiaoai_apikey
-except:
-    apiKey: str = "寄"
-
-try:
-    Bot_NICKNAME: str = nonebot.get_driver(
-    ).config.bot_nickname     # bot的nickname,可以换成你自己的
-    Bot_MASTER: str = nonebot.get_driver().config.bot_master      # bot的主人名称,也可以换成你自己的
-except:
-    Bot_NICKNAME: str = "脑积水"
-    Bot_MASTER: str = "脑积水"
-
-try:
-    api_key = nonebot.get_driver().config.openai_api_key
-except:
-    api_key = '寄'
-
-try:
-    max_tokens = nonebot.get_driver().config.openai_max_tokens
-except:
-    max_tokens = 1000
+config = nonebot.get_driver().config
+xiaoai_api_key: str = getattr(config, "xiaoai_apikey", "寄")
+Bot_NICKNAME: str = getattr(config, "bot_nickname", "脑积水")
+Bot_MASTER: str = getattr(config, "Bot_MASTER", "脑积水")
+openai_api_key: str = getattr(config, "openai_api_key", "寄")
+max_tokens: int = getattr(config, "openai_max_tokens", 1000)
+cd_time: int = getattr(config, "openai_cd_time", 60)
 
 # 载入词库(这个词库有点涩)
 AnimeThesaurus = json.load(open(Path(__file__).parent.joinpath(
@@ -135,7 +120,7 @@ def text_to_png(msg: str) -> bytes:
 
 def get_openai_reply(prompt: str) -> str:
     """从openai api拿到消息"""
-    openai.api_key = api_key
+    openai.api_key = openai_api_key
     response = openai.Completion.create(
         model="text-davinci-003",
         prompt=prompt,

--- a/nonebot_plugin_smart_reply/utils.py
+++ b/nonebot_plugin_smart_reply/utils.py
@@ -16,6 +16,7 @@ config = nonebot.get_driver().config
 xiaoai_api_key: str = getattr(config, "xiaoai_apikey", "寄")
 Bot_NICKNAME: str = getattr(config, "bot_nickname", "脑积水")
 Bot_MASTER: str = getattr(config, "Bot_MASTER", "脑积水")
+reply_private: bool = getattr(config, "ai_reply_private", False)
 openai_api_key: str = getattr(config, "openai_api_key", "寄")
 max_tokens: int = getattr(config, "openai_max_tokens", 1000)
 cd_time: int = getattr(config, "openai_cd_time", 60)


### PR DESCRIPTION
现在所有私聊消息都会触发聊天，用其他插件的私聊指令时候一直插嘴实在难受，所以新增一个配置项来控制。
使用相对方便的方式获取配置项。同时也修复了Bot_NICKNAME、Bot_MASTER其中一个未配置，另一个会变为默认值的问题。
顺带修改了小爱和OpenAI的kay在代码里的名称，好区分一些。
OpenAI两句固定回复语里的自称从“本喵”改成配置的昵称，更有沉浸感。